### PR TITLE
cleaner fix for data.table 1.12.6 in R-devel 4.0.0 #30

### DIFF
--- a/R/bind.R
+++ b/R/bind.R
@@ -39,14 +39,7 @@ rbind_df <- function(list_df) {
 #' @examples
 #' cbind_df(list(iris, iris))
 cbind_df <- function(list_df) {
-
-  res <- do.call(cbind.data.frame, list_df)
-
-  if (data.table::is.data.table(list_df[[1]])) {
-    data.table::as.data.table(res)
-  } else {
-    res
-  }
+  do.call(cbind, list_df)
 }
 
 ################################################################################


### PR DESCRIPTION
Hi Florian,

Thanks for updating 0.1.11 on CRAN so quickly.  That should work. But this PR is what I had in mind.  Please could you merge this approach and include this in your next update.  I'm fearful that others will see your change, think that extra `if()` is necessary and then start to copy it.   All that needed to be done was change the `cbind.data.frame` call to just `cbind`.

I've tested this works in all combinations of data.table 1.12.4/1.12.6 and R before and after 4.0.0.

Upstream issue: https://github.com/Rdatatable/data.table/issues/3971

Thanks, Matt 
